### PR TITLE
Correct help link to point to the right plugin

### DIFF
--- a/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
@@ -15,7 +15,7 @@
                     <div class="sectionTitleContainer flex align-items-center">
                         <h2 class="sectionTitle">Skin Manager</h2>
                         <a is="emby-linkbutton" class="raised button-alt headerHelpButton emby-button" target="_blank"
-                           href="https://github.com/danieladov/jellyfin-plugin-themesongs">Help</a>
+                           href="https://github.com/danieladov/jellyfin-plugin-skin-manager">Help</a>
                     </div>
                     <div class="verticalSection">
                         <p>


### PR DESCRIPTION
The Help button on the plugin settings page linked to the themesong plugin, not the skin manager.