### PR TITLE
added codeblock for URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Jellyfin Skin Manager is a plugin that helps you to download and install skins;
 
 
 ## From Repository
-1. In jellyfin, go to dashboard -> plugins -> Repositories -> add and paste this link https://raw.githubusercontent.com/danieladov/JellyfinPluginManifest/master/manifest.json
+1. In jellyfin, go to dashboard -> plugins -> Repositories -> add and paste this link:
+```
+https://raw.githubusercontent.com/danieladov/JellyfinPluginManifest/master/manifest.json
+```
 2. Go to Catalog and search for Skin Manager
 3. Click on it and install
 4. Restart Jellyfin


### PR DESCRIPTION
there was a part bugging me in README.md where a url wasnt in a codeblock and i wanted it to be easier to copy so i put it in one